### PR TITLE
Return translation instead of tuple

### DIFF
--- a/drf_enum_field/fields.py
+++ b/drf_enum_field/fields.py
@@ -1,9 +1,10 @@
+from django.utils.translation import ugettext_lazy as _
 from rest_framework.fields import ChoiceField
 
 
 class EnumField(ChoiceField):
     default_error_messages = {
-        'invalid': ("No matching enum type.",)
+        'invalid': _("No matching enum type.")
     }
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Fixes Attributerror: 'tuple' object has no attribute 'format' when POSTing with no value for an Enum field.
